### PR TITLE
from python_thingset.thingset import ThingSet -> from python_thingset import ThingSet

### DIFF
--- a/python_thingset/__init__.py
+++ b/python_thingset/__init__.py
@@ -1,0 +1,1 @@
+from .thingset import ThingSet

--- a/python_thingset/__init__.py
+++ b/python_thingset/__init__.py
@@ -1,1 +1,3 @@
 from .thingset import ThingSet
+
+__all__ = ["ThingSet"]

--- a/python_thingset/backends/__init__.py
+++ b/python_thingset/backends/__init__.py
@@ -2,3 +2,5 @@ from .backend import ThingSetBackend
 from .can import ThingSetCAN
 from .serial import ThingSetSerial
 from .socket import ThingSetSock
+
+__all__ = ["ThingSetBackend", "ThingSetCAN", "ThingSetSerial", "ThingSetSock"]

--- a/python_thingset/backends/__init__.py
+++ b/python_thingset/backends/__init__.py
@@ -1,0 +1,4 @@
+from .backend import ThingSetBackend
+from .can import ThingSetCAN
+from .serial import ThingSetSerial
+from .socket import ThingSetSock

--- a/python_thingset/backends/can.py
+++ b/python_thingset/backends/can.py
@@ -12,7 +12,7 @@ import isotp
 
 from .backend import ThingSetBackend
 from ..client import ThingSetClient
-from ..encoders.binary import ThingSetBinaryEncoder
+from ..encoders import ThingSetBinaryEncoder
 from ..id import ThingSetID
 from ..log import get_logger
 

--- a/python_thingset/backends/serial.py
+++ b/python_thingset/backends/serial.py
@@ -10,7 +10,7 @@ from serial import Serial as PySerial
 
 from .backend import ThingSetBackend
 from ..client import ThingSetClient
-from ..encoders.text import ThingSetTextEncoder
+from ..encoders import ThingSetTextEncoder
 from ..log import get_logger
 
 

--- a/python_thingset/backends/socket.py
+++ b/python_thingset/backends/socket.py
@@ -9,7 +9,7 @@ from typing import Union
 
 from .backend import ThingSetBackend
 from ..client import ThingSetClient
-from ..encoders.binary import ThingSetBinaryEncoder
+from ..encoders import ThingSetBinaryEncoder
 
 
 class Sock(ThingSetBackend):

--- a/python_thingset/cli.py
+++ b/python_thingset/cli.py
@@ -10,7 +10,7 @@ import argparse
 from time import sleep
 from typing import Union
 
-from .backends.backend import ThingSetBackend
+from .backends import ThingSetBackend
 from .thingset import ThingSet
 
 

--- a/python_thingset/client.py
+++ b/python_thingset/client.py
@@ -6,7 +6,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, List, Union
 
-from .backends.backend import ThingSetBackend
+from .backends import ThingSetBackend
 from .response import ThingSetResponse, ThingSetStatus, ThingSetValue
 from .log import get_logger
 

--- a/python_thingset/encoders/__init__.py
+++ b/python_thingset/encoders/__init__.py
@@ -1,0 +1,2 @@
+from .binary import ThingSetBinaryEncoder
+from .text import ThingSetTextEncoder

--- a/python_thingset/encoders/__init__.py
+++ b/python_thingset/encoders/__init__.py
@@ -1,2 +1,4 @@
 from .binary import ThingSetBinaryEncoder
 from .text import ThingSetTextEncoder
+
+__all__ = ["ThingSetBinaryEncoder", "ThingSetTextEncoder"]

--- a/python_thingset/response.py
+++ b/python_thingset/response.py
@@ -9,7 +9,7 @@ from typing import Any, List, Union
 
 import cbor2
 
-from .backends.backend import ThingSetBackend
+from .backends import ThingSetBackend
 
 
 @dataclass

--- a/python_thingset/thingset.py
+++ b/python_thingset/thingset.py
@@ -5,10 +5,7 @@
 #
 from typing import Any, List, Union
 
-from .backends.backend import ThingSetBackend
-from .backends.can import ThingSetCAN
-from .backends.serial import ThingSetSerial
-from .backends.socket import ThingSetSock
+from .backends import ThingSetBackend, ThingSetCAN, ThingSetSerial, ThingSetSock
 from .response import ThingSetResponse
 
 


### PR DESCRIPTION
Populates various `__init__.py` files to treat containing folders as packages, resulting in simplified import paths. This results in a cleaner import at the application layer:

Previously:
```
from python_thingset.thingset import ThingSet
```

Now:
```
from python_thingset import ThingSet
```