### PR TITLE
Default get_paths to False

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "python_thingset"
-version = "0.2.6"
+version = "0.2.7"
 description = "A Python library for ThingSet functionality"
 authors = [
     { name = "Adam Mitchell", email = "adam.mitchell@brillpower.com" }

--- a/python_thingset/client.py
+++ b/python_thingset/client.py
@@ -20,7 +20,7 @@ class ThingSetClient(ABC):
         parent_id: Union[int, str],
         ids: List[Union[int, str]],
         node_id: Union[int, None] = None,
-        get_paths: bool = True,
+        get_paths: bool = False,
     ) -> ThingSetResponse:
         values = []
 
@@ -55,7 +55,7 @@ class ThingSetClient(ABC):
         self,
         value_id: Union[int, str],
         node_id: Union[int, None] = None,
-        get_paths: bool = True,
+        get_paths: bool = False,
     ) -> ThingSetResponse:
         values = []
 


### PR DESCRIPTION
Not all ThingSet implementations support this feature, so disable it by default